### PR TITLE
Add cstddef header to VectorHash.h

### DIFF
--- a/src/VectorHash.h
+++ b/src/VectorHash.h
@@ -2,6 +2,7 @@
 #define VECTOR_HASH_H
 
 #include <vector>
+#include <cstddef>
 
 struct VectorHash {
   size_t operator()(const std::vector<int>& v) const {


### PR DESCRIPTION
I was running into a compilation error with g++-11 on Ubuntu jammy complaining `size_t` was not defined and suggesting to add the `cstddef` header.  Adding it permitting compilation. 

I am a little surprised this did not come up at CRAN ...   Hope this helps.